### PR TITLE
Add unit tests for GPIO and ADC

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,3 +7,10 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+[env:uno]
+platform = atmelavr
+board = uno
+lib_extra_dirs = ./
+lib_deps = libavrlite
+framework = arduino
+test_build_project_src = yes

--- a/test/test_adc/test_adc.c
+++ b/test/test_adc/test_adc.c
@@ -1,0 +1,52 @@
+/*
+ * This file contains unit tests for making
+ * sure that the ADC functionality in libavrlite
+ * works as intended.
+ *
+ * Only tests constants for now. Will probably add
+ * legit tests once timer/pwm support exists.
+ */
+
+#include <util/delay.h>
+#include <avrl/adc.h>
+#include <unity.h>
+
+void test_adc_numbers(void) {
+    /* Make sure the adc number constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, ADC0);
+    TEST_ASSERT_EQUAL(1, ADC1);
+    TEST_ASSERT_EQUAL(2, ADC2);
+    TEST_ASSERT_EQUAL(3, ADC3);
+    TEST_ASSERT_EQUAL(4, ADC4);
+    TEST_ASSERT_EQUAL(5, ADC5);
+}
+
+void test_adc_refs(void) {
+    /* Make sure the adc reference constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, ADC_REFERENCE_AREF);
+    TEST_ASSERT_EQUAL(1, ADC_REFERENCE_AVCC);
+    TEST_ASSERT_EQUAL(3, ADC_REFERENCE_1V1);
+}
+
+void test_adc_adjust_constants(void) {
+    /* Make sure the adc adjust constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, ADC_ADJUST_RIGHT);
+    TEST_ASSERT_EQUAL(1, ADC_ADJUST_LEFT);
+}
+
+int main() {
+    // NOTE!!! Wait for >2 secs
+    // if board doesn't support software reset via Serial.DTR/RTS
+    _delay_ms(2000);
+
+    UNITY_BEGIN();    // Start tests
+
+    RUN_TEST(test_adc_numbers);
+    RUN_TEST(test_adc_refs);
+    RUN_TEST(test_adc_adjust_constants);
+
+    UNITY_END();
+}

--- a/test/test_gpio/test_gpio.c
+++ b/test/test_gpio/test_gpio.c
@@ -1,0 +1,88 @@
+/*
+ * This file contains unit tests for making
+ * sure that the basic GPIO functionality in libavrlite
+ * works as intended by flashing the builtin LED.
+ */
+
+#include <util/delay.h>
+#include "avrl/gpio.h"
+#include <unity.h>
+
+// Define builtin LED pin num
+const uint8_t LED_PORT = GPIOB;
+const uint8_t LED_PIN = GPIO5;
+
+void test_pin_numbers(void) {
+    /* Make sure the pin number constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, GPIO0);
+    TEST_ASSERT_EQUAL(1, GPIO1);
+    TEST_ASSERT_EQUAL(2, GPIO2);
+    TEST_ASSERT_EQUAL(3, GPIO3);
+    TEST_ASSERT_EQUAL(4, GPIO4);
+    TEST_ASSERT_EQUAL(5, GPIO5);
+    TEST_ASSERT_EQUAL(6, GPIO6);
+    TEST_ASSERT_EQUAL(7, GPIO7);
+}
+
+void test_gpio_mode_constants(void) {
+    /* Make sure the gpio mode constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, GPIO_MODE_INPUT);
+    TEST_ASSERT_EQUAL(1, GPIO_MODE_OUTPUT);
+}
+
+void test_gpio_pupd_constants(void) {
+    /* Make sure the gpio pullup constants weren't
+     * changed by accident. */
+    TEST_ASSERT_EQUAL(0, GPIO_PUPD_NONE);
+    TEST_ASSERT_EQUAL(1, GPIO_PUPD_PULLUP);
+}
+
+void test_led_state_high(void) {
+    /* Verify that GPIO can be set HI properly. */
+    gpio_set(LED_PORT, LED_PIN);
+    _delay_ms(1000);
+    TEST_ASSERT_EQUAL(1, gpio_get(LED_PORT, LED_PIN));
+}
+
+void test_led_state_low(void) {
+    /* Verify that GPIO can be set LO properly. */
+    gpio_clear(LED_PORT, LED_PIN);
+    _delay_ms(1000);
+    TEST_ASSERT_EQUAL(0, gpio_get(LED_PORT, LED_PIN));
+}
+
+void test_led_state_toggle(void) {
+    /* Verify that GPIO can be toggled properly. */
+    uint8_t gpio = gpio_get(LED_PORT, LED_PIN);
+    gpio_toggle(LED_PORT, LED_PIN);
+    _delay_ms(1000);
+    TEST_ASSERT_EQUAL(!gpio, gpio_get(LED_PORT, LED_PIN));
+}
+
+int main() {
+    // NOTE!!! Wait for >2 secs
+    // if board doesn't support software reset via Serial.DTR/RTS
+    _delay_ms(2000);
+
+    UNITY_BEGIN();    // Start tests
+    RUN_TEST(test_pin_numbers);
+    RUN_TEST(test_gpio_mode_constants);
+    RUN_TEST(test_gpio_pupd_constants);
+
+    // Setup the LED pin
+    gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_PIN);
+
+    // Reset it
+    RUN_TEST(test_led_state_high);
+    RUN_TEST(test_led_state_low);
+
+    // Toggle it on and off
+    RUN_TEST(test_led_state_toggle);
+    RUN_TEST(test_led_state_toggle);
+
+    UNITY_END();
+    return 0;
+}
+


### PR DESCRIPTION
This PR adds unit tests for GPIO and ADC functionality of the library. As of now, I feel that my knowledge is too lacking to write effective tests for USART and interrupts (I should probably know how the functionality works before unit testing it! :) ) so I'm submitting only these two for now. From my current understanding, they should not be _that_ hard to test, but I'd like to push it off to a later PR.

As I could not find a way to actually accurately unit test the ADC on the atmega328p board, it currently only tests a couple header-defined constants.